### PR TITLE
Better Error Handeling

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--colour --format documentation

--- a/.rvmrc
+++ b/.rvmrc
@@ -1,0 +1,2 @@
+rvm --create use 1.9.2-p320@disco_pop
+

--- a/lib/restafari/invalid_response_error.rb
+++ b/lib/restafari/invalid_response_error.rb
@@ -1,0 +1,5 @@
+require 'json'
+module Restafari
+  class InvalidResponseError < StandardError
+  end
+end

--- a/lib/restafari/response.rb
+++ b/lib/restafari/response.rb
@@ -15,7 +15,7 @@ module Restafari
       elsif @resp.is_a?(Hash)
         @data = @resp[:body]
       else
-        @data = nil
+        raise StandardError.new(@resp)
       end
     end
 

--- a/lib/restafari/response.rb
+++ b/lib/restafari/response.rb
@@ -5,7 +5,20 @@ module Restafari
 
     def initialize(resp)
       @resp = resp
-      @data = @resp.is_a?(Hash) ? @resp[:body] : JSON.parse(@resp.body)
+
+      if @resp.is_a?(Hash)
+        @data = @resp[:body]
+      else
+        if @resp.is_a?(Faraday::Response)
+          begin
+            @data = JSON.parse(@resp.body)
+          rescue => e
+            @data = @resp.body
+          end
+        else
+          @data = nil
+        end
+      end
     end
 
     def [](i)

--- a/lib/restafari/response.rb
+++ b/lib/restafari/response.rb
@@ -6,18 +6,16 @@ module Restafari
     def initialize(resp)
       @resp = resp
 
-      if @resp.is_a?(Hash)
+      if @resp.is_a?(Faraday::Response)
+        begin
+          @data = JSON.parse(@resp.body)
+        rescue => e
+          @data = @resp.body
+        end
+      elsif @resp.is_a?(Hash)
         @data = @resp[:body]
       else
-        if @resp.is_a?(Faraday::Response)
-          begin
-            @data = JSON.parse(@resp.body)
-          rescue => e
-            @data = @resp.body
-          end
-        else
-          @data = nil
-        end
+        @data = nil
       end
     end
 

--- a/lib/restafari/response.rb
+++ b/lib/restafari/response.rb
@@ -1,4 +1,6 @@
 require 'json'
+require_relative 'invalid_response_error'
+
 module Restafari
   class Response
     attr_reader :data, :resp
@@ -15,7 +17,7 @@ module Restafari
       elsif @resp.is_a?(Hash)
         @data = @resp[:body]
       else
-        raise StandardError.new(@resp)
+        raise InvalidResponseError.new(@resp)
       end
     end
 

--- a/lib/restafari/version.rb
+++ b/lib/restafari/version.rb
@@ -1,3 +1,3 @@
 module Restafari
-  VERSION = "0.8.2"
+  VERSION = "0.8.3"
 end

--- a/spec/restafari/response_spec.rb
+++ b/spec/restafari/response_spec.rb
@@ -37,9 +37,11 @@ describe Restafari::Response do
     end
 
     context "when the response is nil" do
-      let(:response){ nil }
-      it "should be nil" do
-        new_response.should be_nil
+      let(:response){ "something went wrong" }
+      it "should raise an InvalidResponseError exception" do
+        expect{
+          Restafari::Response.new(response)
+        }.to raise_error( Restafari::InvalidResponseError, response)
       end
     end
 

--- a/spec/restafari/response_spec.rb
+++ b/spec/restafari/response_spec.rb
@@ -2,7 +2,59 @@ require "spec_helper"
 
 describe Restafari::Response do
 
-  it "should handle response of type hash" do
-    Restafari::Response.new({body:{"x"=>2}}).x.should == 2
+  let(:value) { "some value" }
+  let(:body) { {"x"=>value} }
+
+  describe "creating a new response" do
+
+    def new_response
+      Restafari::Response.new(response).data
+    end
+
+    context "when the response is a Hash" do
+      let(:response){ { body:body } }
+      it "should use the response body" do
+        new_response.should eq body
+      end
+    end
+
+    context "when the response is a Faraday::Response" do
+
+      let(:response){ Faraday::Response.new(body: body) }
+
+      context "when the response body is parseable to JSON" do
+        it "should parse the response body to JSON" do
+          new_response.should eq body
+        end
+      end
+
+      context "when the response body is not parseable to JSON" do
+        let(:body){ "not parseable to JSON" }
+        it "should use the whole response" do
+          new_response.should eq body
+        end
+      end
+    end
+
+    context "when the response is nil" do
+      let(:response){ nil }
+      it "should be nil" do
+        new_response.should be_nil
+      end
+    end
+
   end
+
+
+  describe "accessing the response body data" do
+
+    let(:response){ { body: {"key" => value} } }
+
+    it "should allow access to response keys as methods" do
+      Restafari::Response.new(response).key.should eq value
+    end
+
+  end
+
+
 end


### PR DESCRIPTION
also merge along with:
https://github.com/TheGiftsProject/slice_api/pull/7

Restafari::Response JSON.parse was throwing:
# (JSON::ParserError) "A JSON text must at least contain two octets!"

when trying to parse invalid values. 
see:
http://stackoverflow.com/questions/8390256/a-json-text-must-at-least-contain-two-octets
